### PR TITLE
Fixed shell statement

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,7 +31,8 @@ elif [[ $FLAVOR == "cli" ]]; then
     build_container cli
 else
     build_container cli
-    if [ $? eq 1 ]; then
+    if [ $? -ne 0 ]; then
+    	echo "Building container failed. Exiting"
 	exit 1
     fi
     build_container novnc

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ else
     build_container cli
     if [ $? -ne 0 ]; then
     	echo "Building container failed. Exiting"
-	exit 1
+	return 1
     fi
     build_container novnc
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,4 +38,4 @@ else
     build_container novnc
 fi
 
-exit $?
+return $?


### PR DESCRIPTION
A few things:
* equality statements need "-" in front of the check type
* Changed to != 0 to catch more errors
* Added error echo
* Changed exit to return since that caused parent script (and container) to exit unexpectedly