### PR TITLE
Add overwriting of AZURE/SSH Volume info

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -43,8 +43,8 @@ MODE=${3:-tutorial}
 REPOSITORY=rgardler
 CONTAINER_NAME=simdem_$FLAVOR
 SCRIPTS_VOLUME=${CONTAINER_NAME}_scripts
-AZURE_VOLUME=${AZURE_VOLUME:-azure_data}
-SSH_VOLUME=${SSH_VOLUME:-ssh_data}
+AZURE_VOLUME=${AZURE_VOLUME:-$HOME/.azure}
+SSH_VOLUME=${SSH_VOLUME:-$HOME/.ssh}
 
 if [[ $FLAVOR == "novnc" ]]; then
     HOME="/headless"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -43,8 +43,8 @@ MODE=${3:-tutorial}
 REPOSITORY=rgardler
 CONTAINER_NAME=simdem_$FLAVOR
 SCRIPTS_VOLUME=${CONTAINER_NAME}_scripts
-AZURE_VOLUME=azure_data
-SSH_VOLUME=ssh_data
+AZURE_VOLUME=${AZURE_VOLUME:-azure_data}
+SSH_VOLUME=${SSH_VOLUME:-ssh_data}
 
 if [[ $FLAVOR == "novnc" ]]; then
     HOME="/headless"


### PR DESCRIPTION
I'm not sure how your environment is setup; however, if I want to interact with the Azure CLI, then I need to mount my local .azure directory for it to work.

Expected use: 
`AZURE_VOLUME=/Users/thfalgou/.azure scripts/run.sh cli /Users/thfalgou/git/azure/acs-demos/incubator/aci demo`

Personally, I think $HOME/.azure should be the default value, but I don't know how much that would break.