### PR TITLE
custom handling of commands plus a handful of bug fixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ env.local.json
 
 # Python
 __pycache__
-simdem=env/
+simdem-env/
+

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ port = 8080
 
 # Set is_debug to True if you want to run in debug mode. This setting
 # can be overriden in the command like with the `--debug true` option.
-is_debug = True
+is_debug = False
 
 # Available modes of execution
 modes = [ "tutorial", "demo", "learn", "test", "script" ]

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-SIMDEM_VERSION = "0.8.0-dev"
+SIMDEM_VERSION = "0.8.1-dev"
 SIMDEM_TEMP_DIR = "~/.simdem/tmp"
 
 # When in demo mode we insert a small random delay between characters.

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ port = 8080
 
 # Set is_debug to True if you want to run in debug mode. This setting
 # can be overriden in the command like with the `--debug true` option.
-is_debug = False
+is_debug = True
 
 # Available modes of execution
 modes = [ "tutorial", "demo", "learn", "test", "script" ]

--- a/demo.py
+++ b/demo.py
@@ -62,11 +62,13 @@ class Demo(object):
         var_list = []
         if matches:
             for var in matches:
+                have_value = False
                 if self.env:
                     for item in self.env.get():
-                        if var == item[0]:
+                        if var == item:
+                            have_value = True
                             break
-                if len(var) > 0 and not '$(' + var + ')' in self.current_command:
+                if len(var) > 0 and not have_value and not '$(' + var + ')' in self.current_command:
                     value = self.ui.get_shell().run_command("echo $" + var).strip()
                     if len(value) == 0:
                         var_list.append(var)

--- a/demo_scripts/simdem/README.md
+++ b/demo_scripts/simdem/README.md
@@ -36,11 +36,12 @@ following paths next:
   2. [Hello World Demo](demo/README.md)
   3. [Build a Hello World script](tutorial/README.md)
   4. [Write SimDem documents](syntax/README.md)
-  5. [Configure your scripts through variables](variables/README.md)
-  6. [Write multi-part documents](multipart/README.md)
-  7. [Use your documents as interactive tutorials or demos](running/README.md)
-  8. [Use your documents as automated tests](test/README.md)
-  9. [Build an SimDem container](building/README.md)
+  5. [Special Commands](special_commands/README.md)
+  6. [Configure your scripts through variables](variables/README.md)
+  7. [Write multi-part documents](multipart/README.md)
+  8. [Use your documents as interactive tutorials or demos](running/README.md)
+  9. [Use your documents as automated tests](test/README.md)
+ 10. [Build an SimDem container](building/README.md)
 
 
   

--- a/demo_scripts/simdem/special_commands/README.md
+++ b/demo_scripts/simdem/special_commands/README.md
@@ -1,0 +1,37 @@
+# Special Commands
+
+Some commands will be intercepted by SimDem and handled as special
+commands. For example, we might interccept a command to open a browser
+at a specific page and handle it differently in a headless CLI
+environment to how it is handled in a Web UI environment.
+
+In fact lets look at that use case as an example.
+
+## Opening a Browser Tab
+
+On linux the command `xdg-open` is the accepted way of opening a
+browser, therefore it is the accepted way of having such a command in
+SimDem script. However, this poses a problem, behoviour of this
+command will be different in different UI environments.
+
+For example, on a headliess CLI environment it will attempt to open
+"lynx" or similar text based browsers. Since these are interactive
+programs they will not work in SimDem. If running in a desktop
+environment it will attempt to open the preferred browser.
+
+SimDem will intercept this command and handle it appropriately. That
+is, in a headless CLI environment it will convert the command to a
+"curl -I" command, this at least allows us to ensure that there is a
+resposne from the URL provided. When running in a Web UI it will open
+a new browser tab (at least at the time of writing, we may decide to
+integrate this with the Web UI at some point).
+
+### In Action
+
+The command block below contains the `xdg-open` command, depending on
+whether you are running in the Web UI or the CLI you will see
+different behaviour, as described above.
+
+```
+xdg-open http://bing.com
+```

--- a/demo_scripts/simdem/syntax/README.md
+++ b/demo_scripts/simdem/syntax/README.md
@@ -112,8 +112,9 @@ For example, this document offers next steps options.
 
 # Next Steps
 
-  1. [Configure your scripts through variables](../variables/README.md)
-  2. [Build a Hello World script](../tutorial/README.md)
-  3. [SimDem Index](../README.md)
-  4. [Write multi-part documents](../multipart/README.md)
-  5. [Use your documents as interactive tutorials or demos](../running/README.md)
+  1. [Special Commands](special_commands/README.md)
+  2. [Configure your scripts through variables](../variables/README.md)
+  3. [Build a Hello World script](../tutorial/README.md)
+  4. [SimDem Index](../README.md)
+  5. [Write multi-part documents](../multipart/README.md)
+  6. [Use your documents as interactive tutorials or demos](../running/README.md)

--- a/demo_scripts/test/README.md
+++ b/demo_scripts/test/README.md
@@ -16,7 +16,7 @@ echo $SIMDEM_VERSION
 Results:
 
 ```
-0.8.0-dev
+0.8.1-dev
 ```
 
 ## Clean test working files

--- a/demo_scripts/test/environment_test.md
+++ b/demo_scripts/test/environment_test.md
@@ -129,10 +129,18 @@ Test value for the test script
 # Setting new variables in script
 
 If a script sets a variable during execution this will be recorded in
-the SimDem environment.
+the SimDem environment. This includes setting to an empty string, this
+will prevent SimDem interactively requesting a value for the variable
+(or setting a dummt value in test mode).
 
 ```
-new_var=new_val
+new_var=""
+echo $new_var
+```
+
+Results:
+
+```
 ```
 
 # Capturing the output of commands

--- a/js/common.js
+++ b/js/common.js
@@ -7,3 +7,13 @@ function log(type, msg) {
     $('#log').prepend('<br/>' + $('<div/>').text(new Date() + " : " + type + " : " + msg).html());
 }
 
+function open_tab(url) {
+    var win = window.open(url, '_blank');
+    if (win) {
+	//Browser has allowed it to be opened
+	win.focus();
+    } else {
+	//Browser has blocked it
+	alert('Please allow popups for this website');
+    }
+}

--- a/js/console.js
+++ b/js/console.js
@@ -12,6 +12,11 @@ function init_console() {
 	$('#console').html('');
 	log("CONSOLE", "clear")
     });
+
+    socket.on('open_tab', function(url) {
+	open_tab(url)
+	log("CONSOLE", "Open tab for " + url)
+    });
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,35 +1,60 @@
+function removeEarlier() {
 # Remove < 0.7.0 version
-if [ -f ~/bin/simdem.py ]; then
-    echo "Since version 0.7.0 Simdem is installed in a different way, we need to remove the old Simdem version."
-    rm ~/bin/simdem.py
-    rm ~/bin/simdem
-fi
+    if [ -f ~/bin/simdem.py ]; then
+	echo "Since version 0.7.0 Simdem is installed in a different way, we need to remove the old Simdem version."
+	rm ~/bin/simdem.py
+	rm ~/bin/simdem
+    fi
 
-if [ -f /usr/local/bin/simdem.py ]; then
-    echo "Since version 0.7.0 Simdem is installed in a different way, we need to remove the old Simdem version."
-    sudo rm /usr/local/bin/simdem.py
-    sudo rm /usr/local/bin/simdem
-fi
+    if [ -f /usr/local/bin/simdem.py ]; then
+	echo "Since version 0.7.0 Simdem is installed in a different way, we need to remove the old Simdem version."
+	sudo rm /usr/local/bin/simdem.py
+	sudo rm /usr/local/bin/simdem
+    fi
 
-if [ -f /.dockerenv ]; then
-    echo "Running in a Docker container"
-    IS_DOCKER=true
-    INSTALL_DIR=~/bin/simdem-dev/
-else
-    echo "Not running in a Docker container"
-    IS_DOCKER=false
-    INSTALL_DIR=/usr/local/bin/simdem-dev/
-fi
+    if [ -f /.dockerenv ]; then
+	echo "Running in a Docker container"
+	IS_DOCKER=true
+	INSTALL_DIR=~/bin/simdem-dev/
+    else
+	echo "Not running in a Docker container"
+	IS_DOCKER=false
+	INSTALL_DIR=/usr/local/bin/simdem-dev/
+    fi
+}
+
+function installLinuxDependencies() {
+    if [ "$IS_DOCKER" = true ]; then
+	apt update
+	apt-get install -y python3-pip
+    else
+	sudo apt update
+	sudo apt-get install -y python3-pip
+    fi
+}
 
 MAIN_FILE=main.py
 SYMLINK=simdem
 
+if [ -f /.dockerenv ]; then
+    echo "Running in a Docker container"
+    IS_DOCKER=true
+    INSTALL_DIR=~/bin/
+else
+    echo "Not running in a Docker container"
+    IS_DOCKER=false
+    INSTALL_DIR=/usr/local/bin/
+fi
+
 unameOut="$(uname -s)"
 case "${unameOut}" in
-    Linux*)     sudo apt update; sudo apt-get install -y python3-pip;;
+    Linux*)     installLinuxDependencies;;
     Darwin*)    brew install python3;;
     *)          echo "Unsupported OS: ${unameOut}"
 esac
+
+virtualenv simdem-env
+source simdem-env/bin/activate
 
 pip3 install -r requirements.txt
 

--- a/web.py
+++ b/web.py
@@ -198,3 +198,26 @@ to select it) and a title (to be displayed).
             pass
         return in_string
 
+    def run_special_command(self, command):
+        """Test to see if the command is a spcial command that needs to be
+        handled diferently, these include:
+
+        `xdg-open $URL` - intercepted and converted to an instruction to open a new window
+
+        Returns the response from the command if it was handled by this function,
+        otherwise returns False.
+
+        """
+        if command.startswith("xdg-open "):
+            self.warning("Since you are running in Web UI mode it is not possible to execute xdg-open commands.")
+            self.warning("Attempting to open a new browser window instead.")
+
+            url = command[9:]
+            socketio.emit('open_tab',
+                          url,
+                          namespace='/console')
+            
+            self.warning("Note that this may break tests.")
+            return "<opened tab for " + url + ">"
+        else:
+            return False


### PR DESCRIPTION
Add ability to intercept some commands so we can handle them differently in different execution environments, e.g. xdg-open is converted to curl in headless mode, but opens a new tab in WebUI mode

If a script explicitly sets a var as being empty then SimDem should not ask user for a value nor set a dummy value in test mode

Fix installer in cloudshell environment


