### PR TITLE
Expand variables on special commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ does not work because of the need to install some dependencies that
 CloudShell does not like. We are therefore going to use an earlier
 version of SimDem, this means some of the more recent features will
 not be available. See issues https://github.com/Azure/simdem/issues/19
-and https://github.com/Azure/simdem/issues/20.
+and https://github.com/Azure/simdem/issues/22.
 
 
 ```

--- a/demo.py
+++ b/demo.py
@@ -380,6 +380,8 @@ class Demo(object):
                 in_prerequisites = False
                 self.ui.heading(line["text"])
             elif line["type"] == "executable":
+                if line["text"].strip() == "":
+                    break
                 if not self.is_learning:
                     self.ui.prompt()
                     self.ui.check_for_interactive_command()

--- a/demo_scripts/simdem/variables/README.md
+++ b/demo_scripts/simdem/variables/README.md
@@ -76,6 +76,27 @@ SimDem
 
 ```
 
+### Defining variables can be important
+
+Because SimDem will interactively ask for values for undefined
+variables it is sometimes necessary to first declare a variable to
+prevent this action. For example:
+
+```
+i=0
+for i in {0..4}; do echo "Welcome $i times"; done
+```
+
+Results:
+
+```
+Welcome 0 times
+Welcome 1 times
+Welcome 2 times
+Welcome 3 times
+Welcome 4 times
+```
+
 ## User provided environment
 
 Since it is helpful to provide configuration files in published

--- a/demo_scripts/test/README.md
+++ b/demo_scripts/test/README.md
@@ -108,7 +108,12 @@ Tue Jun  6 15:23:53 UTC 2017
 
 # For Loop
 
+Because SimDem will interactively ask for values for undefined
+variables it is sometimes necessary to first declare a variable to
+prevent this action. For example:
+
 ```
+i=0
 for i in {0..10}; do echo "Welcome $i times"; done
 ```
 
@@ -144,7 +149,4 @@ Results:
 Normal Underlined Normal
 ```
 
-# Commands that do not work
 
-  * ping bing.com
-  * curl bing.com

--- a/demo_scripts/test/environment_test.md
+++ b/demo_scripts/test/environment_test.md
@@ -126,6 +126,31 @@ Results:
 Test value for the test script
 ```
 
+# Replacing variables in special commands
+
+Some commands cannot be run in headless mode, e.g. `xdg-open`. These
+commands will be replaced with an appropriate alternative,
+e.g. `curl`. Variables included in such commands will be expanded at
+execution time as expected.
+
+```
+url=http://bing.com
+xdg-open $url
+```
+
+Results: 
+
+```expected_similarity=0.2
+HTTP/1.1 405 Method Not Allowed
+Content-Length: 0
+Server: Microsoft-IIS/10.0
+X-MSEdge-Ref: Ref A: D6871D12117C436FAE3762BC8BCA0C29 Ref B: CO1EDGE0415 Ref C: 2017-08-17T15:37:59Z
+Date: Thu, 17 Aug 2017 15:37:58 GMT
+```
+
+Note: this test will only pass when running in headless mode as the
+`xdg-open` command will be executed in other environments.
+
 # Setting new variables in script
 
 If a script sets a variable during execution this will be recorded in
@@ -140,7 +165,7 @@ echo $new_var
 
 Results:
 
-```
+```expected_similarity=0.2
 ```
 
 # Capturing the output of commands

--- a/web.py
+++ b/web.py
@@ -208,16 +208,19 @@ to select it) and a title (to be displayed).
         otherwise returns False.
 
         """
+        orig_command = command
         if command.startswith("xdg-open "):
             self.warning("Since you are running in Web UI mode it is not possible to execute xdg-open commands.")
-            self.warning("Attempting to open a new browser window instead.")
+            self.warning("Attempting to open a new browser tab instead.")
+            self.warning("Note that this may break tests.")
 
+            command = self.expand_vars(command)
             url = command[9:]
+
             socketio.emit('open_tab',
                           url,
                           namespace='/console')
             
-            self.warning("Note that this may break tests.")
             return "<opened tab for " + url + ">"
         else:
             return False


### PR DESCRIPTION
Some special commands require that variables be expanded, such as 'xdg-open' being converted to opening a browser tab. Fixes #26