### PR TITLE
Strip ANSI codes when displaying in browser #24

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -491,8 +491,7 @@ class Demo(object):
                 expected_similarity = line["expected_similarity"]
             elif (line["type"] != "result" and in_results):
                 # Finishing results section
-                ansi_escape = re.compile(r'\x1b[^m]*m')
-                if not self.is_pass(expected_results, ansi_escape.sub('', actual_results), expected_similarity, True):
+                if not self.is_pass(expected_results, self.strip_ansi(actual_results), expected_similarity, True):
                     self.ui.log("debug", "expected results: '" + expected_results + "'")
                     self.ui.log("debug", "actual results: '" + actual_results + "'")
                     result = False
@@ -502,6 +501,11 @@ class Demo(object):
 
         return result
 
+    def strip_ansi(self, text):
+        """ Strip ANSI codes from a string."""
+        ansi_escape = re.compile(r'\x1b[^m]*m')
+        return ansi_escape.sub('', text)
+    
     def is_pass(self, expected_results, actual_results, expected_similarity = 0.66, is_silent = False):
         """Checks to see if a command execution passes.
         If actual results compared to expected results is within

--- a/web.py
+++ b/web.py
@@ -87,7 +87,7 @@ class WebUi(Ui):
 
     def results(self, text):
         """Display the results of a command execution"""
-        self._send_to_console(text, "results", True)
+        self._send_to_console(self.demo.strip_ansi(text), "results", True)
         
     def clear(self):
         """Clears the console and info panel ready for a new section of the script."""


### PR DESCRIPTION
Strips all ANSI codes before displaying in the browser. It would be better to convert these to HTML classes, but this will do for now. Fixes #24