### PR TITLE
Exit with fail code even on fast fail

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-SIMDEM_VERSION = "0.8.1-dev"
+SIMDEM_VERSION = "0.8.2-dev"
 SIMDEM_TEMP_DIR = "~/.simdem/tmp"
 
 # When in demo mode we insert a small random delay between characters.

--- a/demo.py
+++ b/demo.py
@@ -144,7 +144,7 @@ class Demo(object):
         """
         if self.ui is None:
             raise Exception("Attempt to run a demo before ui is configured")
-
+        
         if mode is None:
             mode = self.ui.get_command(config.modes)
         self.mode = mode
@@ -190,7 +190,7 @@ class Demo(object):
                 if self.is_fast_fail:
                     sys.exit(str(failed_tests) + " test failures. " + str(passed_tests) + " test passes.")
 
-        if not self.is_simulation:
+        if not self.is_simulation and not self.is_testing:
             next_steps = []
             for line in classified_lines:
                 if line["type"] == "next_step" and len(line["text"].strip()) > 0:
@@ -221,7 +221,10 @@ class Demo(object):
                 self.set_script_dir(match.groups()[0], self.script_dir)
                 self.filename = match.groups()[1]
                 self.run(self.mode)
-            
+
+        if failed_tests > 0:
+            sys.exit("Test failures: " + str(failed_tests) + " test failures. " + str(passed_tests) + " test passes.")
+
     def classify_lines(self):
         lines = None
 

--- a/demo_scripts/test/README.md
+++ b/demo_scripts/test/README.md
@@ -16,7 +16,7 @@ echo $SIMDEM_VERSION
 Results:
 
 ```
-0.8.1-dev
+0.8.2-dev
 ```
 
 ## Clean test working files


### PR DESCRIPTION
- when fast fail is off we still need to have a failure exit code if a test failed
- bump version as we published 0.8.1-dev to get this out there
- don't ask for next steps wen running in test mode