### PR TITLE
Add support for language hints

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ port = 8080
 
 # Set is_debug to True if you want to run in debug mode. This setting
 # can be overriden in the command like with the `--debug true` option.
-is_debug = False
+is_debug = True
 
 # Available modes of execution
 modes = [ "tutorial", "demo", "learn", "test", "script", "prep" ]

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ port = 8080
 
 # Set is_debug to True if you want to run in debug mode. This setting
 # can be overriden in the command like with the `--debug true` option.
-is_debug = True
+is_debug = False
 
 # Available modes of execution
 modes = [ "tutorial", "demo", "learn", "test", "script", "prep" ]

--- a/demo.py
+++ b/demo.py
@@ -179,7 +179,7 @@ class Demo(object):
         self.ui.log("debug", "Running script in " + self.mode + " mode")
 
         if mode == "script":
-            # print(self.get_bash_script())
+            print(self.get_bash_script())
             return
         elif mode == "demo":
             # we automate the prereq steps so start in auto mode without simulation
@@ -261,6 +261,7 @@ class Demo(object):
                 self.set_script_dir(match.groups()[0], self.script_dir)
                 self.filename = match.groups()[1]
                 self.run(self.mode)
+
         self.output_results()
 
     def output_results(self):
@@ -320,7 +321,7 @@ logs throughout execution."""
                 passed = False
 
         if len(output) == 0:
-            output = "Completed run succesfully"
+            output = "Completed run."
                 
         if passed:
             if self.parent_script_dir:
@@ -399,8 +400,9 @@ logs throughout execution."""
 
         classified_lines = []
 
+        # TODO: this for loop is awful. We need to make this a state machine. It has grown out of control.
         for line in lines:
-            # print("Line: " + line)
+            # print("Classifying line: " + line)
             if line.startswith("START TEST FILE: "):
                 test_file_path = line[17:]
                 self.ui.log("debug", "Entering test file: " + test_file_path)
@@ -414,26 +416,29 @@ logs throughout execution."""
                 test_file_path = None
             elif line.lower().startswith("results:"):
                 # Entering results section
-                # print("Entering results section")
+                # print("Entering results section " + line)
                 in_results_section = True
-            elif not in_code_block and (line.strip().lower() == "```bash" or line.strip().lower() == "```"):
+            elif not in_code_block and line.strip().lower() == "```bash":
                 # Entering a code block,
-                # print("Entering executable code block")
+                # print("Entering executable code block " + line);
                 in_code_block = True 
+            elif not in_code_block and not in_non_executable_code_block and line.startswith("```"):
+                if (not in_results_section and line.strip() == "```"):
+                        self.ui.warning("Found a backtick line with no language hint near line " + str(len(classified_lines) + 1) + " of '" + file + "'\n. Treating as a non-executable code block, this can result in failed tests if this is intended to be executable. Add a 'bash' language hint to mark it as executable.")
+                # Entering a non executable code block - one we don't know how to execute
+                #print("Entering a non-executable block " + line)
+                in_non_executable_code_block = True
                 pos = line.lower().find("expected_similarity=")
                 if pos >= 0:
                     pos = pos + len("expected_similarity=")
                     similarity = line[pos:]
                     expected_similarity = float(similarity)
                 else:
-                    expected_similarity = 0.66
-            elif not in_code_block and not in_non_executable_code_block and not in_results_section and line.startswith("```"):
-                # Entering a non executable code block - one we don't know how to execute
-                # print("In a non-executable block " + line)
-                in_non_executable_code_block = True
+                    expected_similarity = 0.5
+                # print("Expected similarity set to " + str(expected_similarity))
             elif (in_code_block or in_non_executable_code_block or in_results_section) and line.strip().startswith("```"):
                 # Finishing code block
-                # print("Exiting code block")
+                # print("Exiting code block " + line)
                 in_code_block = False
                 in_non_executable_code_block = False
                 in_results_section = False
@@ -445,7 +450,8 @@ logs throughout execution."""
                                          "text": line})
             elif in_code_block and not in_results_section:
                 # Executable line
-                if line.startswith("#"):
+                # print("Add executable line " + line)
+                if line.strip().startswith("#"):
                     # comment
                     pass
                 else:
@@ -517,13 +523,12 @@ logs throughout execution."""
         failed_tests = 0
         passed_tests = 0
         done_prerequisites = False
-        in_validation = False
-        executed_code_in_this_section = False
-        next_steps = []
 
         if not self.is_testing:
             self.ui.clear()
         for line, next_line in get_next(lines):
+            # print("Executing line of Type: " + line["type"])
+
             if line["type"] == "start_test_file":
                 source_file_directory = os.path.dirname(line["file"])
                 self.ui.get_shell().run_command("pushd " + source_file_directory)
@@ -540,13 +545,14 @@ logs throughout execution."""
             elif line["type"] != "result" and in_results:
                 # Finishing results section
                 if self.is_testing:
-                    ansi_escape = re.compile(r'\x1b[^m]*m')
                     results = self.is_pass(expected_results, self.strip_ansi(actual_results), expected_similarity)
                     self.ui.test_results(results)
                     self.all_results.append(results)
                     if results["passed"]:
                         passed_tests += 1
                     else:
+                        # print("Failed test")
+                        # print(line)
                         failed_tests += 1
                         if self.is_fast_fail:
                             break
@@ -566,6 +572,8 @@ logs throughout execution."""
                         self.is_simulation = True
                         self.is_automated = False
             elif line["type"] == "executable":
+                # print("Execting:")
+                # print(line["text"])
                 if line["text"].strip() == "":
                     break
                 if not self.is_learning:
@@ -585,6 +593,8 @@ logs throughout execution."""
                     self.ui.heading(line["text"])
             else:
                 if not self.is_simulation and (line["type"] == "description" or line["type"] == "validation"):
+                    # print("Description:")
+                    # print(line)
                     # Descriptive text
                     if not self.is_testing:
                         self.ui.description(line["text"])
@@ -674,7 +684,7 @@ logs throughout execution."""
         if self.validate(lines):
             self.ui.information("Validation passed.", True)
         else:
-            self.ui.information("Validation failed. Running prerequisite steps in '" + os.path.abspath(os.path.join(self.script_dir, self.filename)) + "'", True)
+            self.ui.information("Validation failed of pre-requisite execution did not pass. Running prerequisite steps in '" + os.path.abspath(os.path.join(self.script_dir, self.filename)) + "'", True)
             self.ui.new_para()
             self.ui.check_for_interactive_command()
             self.run(mode)

--- a/demo.py
+++ b/demo.py
@@ -428,14 +428,14 @@ logs throughout execution."""
                 # Entering a non executable code block - one we don't know how to execute
                 #print("Entering a non-executable block " + line)
                 in_non_executable_code_block = True
-                pos = line.lower().find("expected_similarity=")
+                pos = line.lower().find("expected_similarity")
                 if pos >= 0:
-                    pos = pos + len("expected_similarity=")
-                    similarity = line[pos:]
+                    pos = line.find("=", pos) + 1
+                    similarity = line[pos:].strip()
                     expected_similarity = float(similarity)
                 else:
                     expected_similarity = 0.5
-                # print("Expected similarity set to " + str(expected_similarity))
+                self.ui.log("debug", "Expected similarity set to " + str(expected_similarity) + " because of line '" + line + "'")
             elif (in_code_block or in_non_executable_code_block or in_results_section) and line.strip().startswith("```"):
                 # Finishing code block
                 # print("Exiting code block " + line)
@@ -581,7 +581,6 @@ logs throughout execution."""
                     self.ui.check_for_interactive_command()
                 self.current_command = line["text"]
                 actual_results = self.ui.simulate_command()
-                executed_code_in_this_section = True
                 self.current_description = ""
                 if not self.is_automated and not next_line["type"] == "executable":
                     self.ui.check_for_interactive_command()

--- a/demo_scripts/simdem/syntax/README.md
+++ b/demo_scripts/simdem/syntax/README.md
@@ -9,7 +9,7 @@ use cases (documentation, tutorial, demo, test and script).
 
 For example, lets take a look at the start of this file this file:
 
-```
+```bash
 head -n 25 README.md 
 ```
 
@@ -28,13 +28,16 @@ aware of. They are detailed in the next few sections.
 ## Code Blocks
 
 In SimDem a code block is marked in exactly the same way it is in
-Markdown, that is with three backticks (``````). Unless a Code Block
+Markdown, that is with three backticks (``````), followed by a language hint. 
+For the code block to be considered executable it is good practice to use
+the `bash` hint. However, the absence of a `bash` hint will result in the
+assumption that it is `bash` code. Unless a Code Block
 is marked as a Results block (see next section) it is assumed that
 this is executable code. SimDem will execute each line individually.
 
 For example:
 
-```
+```bash
 # This is a code block, this comment will be ignored by SimDem
 echo "This command will be 'typed' and executed."
 ```
@@ -42,13 +45,22 @@ echo "This command will be 'typed' and executed."
 Code blocks can optionally be indented to make the markdown more 
 readable. For example:
 
-    ```
+    ```bash
     echo "Hello world indent"
     ```
 
 Results:
 ```expected_similarity=0.6
 Hello world indent
+```
+
+If a code block exists with a different language hint, it will not be
+execute, but instead will be output as formatted code, for example:
+
+```json
+{
+  Foo: "bar"
+}
 ```
 
 ### Command Limitations

--- a/demo_scripts/test/README.md
+++ b/demo_scripts/test/README.md
@@ -15,12 +15,13 @@ echo "This command will be 'typed' and executed."
 Code blocks can optionally be indented to make the markdown more 
 readable. For example:
 
-    ```
+    ```bash
     echo "Hello world indent"
     ```
 
 Results:
-```expected_similarity=0.6
+
+```expected_similarity=0.5
 Hello world indent
 ```
 
@@ -39,13 +40,13 @@ Ensure the test environment is correctly setup.
 
 Create a resource group to deploy Azure Resources to
 
-```
+```bash
 az group create --name $RESOURCE_GROUP_NAME --location $RESOURCE_LOCATION
 ```
 
 ## SimDem version check
 
-```
+```bash
 echo $SIMDEM_VERSION
 ```
 
@@ -60,7 +61,7 @@ Results:
 Ensure that our working files folder exists and that there are no
 residual files from previus test runs.
 
-```
+```bash
 echo $SIMDEM_TEMP_DIR
 mkdir -p $SIMDEM_TEMP_DIR/test
 rm -Rf $SIMDEM_TEMP_DIR/test/*
@@ -90,32 +91,32 @@ demos where a prereq may be included in more than one part.
 The prerequisite script should have run and created a `prereq_ran`
 file.
 
-```
+```bash
 ls $SIMDEM_TEMP_DIR/test
 ```
 
 Results:
 
 ```
-prereq_ran
+nested_prereq_ran  prereq_ran
 ```
 
 
 # Directory Check
 
-```
+```bash
 head -n 1 README.md
 ```
 
 Results: 
 
-``` Expected_Similarity=0.8
+```
 # SimDem Test Script
 ```
 
 # Simple Echo
 
-``` 
+```bash
 echo "Hello world" 
 ```
 
@@ -127,7 +128,7 @@ Hello world
 
 # Code comments
 
-```
+```bash
 # This is a comment and should be ignored
 echo "This output should be displayed, the comment before this line should be ignored"
 ```
@@ -144,14 +145,14 @@ When we know the results will be different and we want to use them in
 tests we need to override the similarity expected by adding
 `expected_similarity=x.y` in the start line of the results block:
 
-```
+```bash
 date
 ```
 
 Results: 
 
 ```expected_Similarity=0.1
-Tue Jun  6 15:23:53 UTC 2017
+Tue Jun  6 15:23:53 UTC 2022
 ```
 
 # For Loop
@@ -160,7 +161,7 @@ Because SimDem will interactively ask for values for undefined
 variables it is sometimes necessary to first declare a variable to
 prevent this action. For example:
 
-```
+```bash
 i=0
 for i in {0..10}; do echo "Welcome $i times"; done
 ```
@@ -187,19 +188,28 @@ To make it easier to write scripts we don't want to include ANSI
 escape sequences (such as colors and text deocration) in the results
 section. SimDem automatically strips these when capturing the results.
 
-```
+```bash
 printf "Normal \e[4mUnderlined\e[24m Normal"
 ```
 
 Results:
 
-```expected_similarity=0.9
+```
 Normal Underlined Normal
 ```
 
 Delete Azure resource group 
 
-```
-az group delete --name $RESOURCE_GROUP_NAME --no-wait --yes
+```bash
+az group delete --name $RESOURCE_GROUP_NAME --no-wait --yes --verbose
 ```
 
+Results:
+
+```expected_similarity=0.5
+Command ran in 2.344 seconds (init: 0.067, invoke: 2.277)
+```
+
+# Tests Complete
+
+Well that's all folks...

--- a/demo_scripts/test/README.md
+++ b/demo_scripts/test/README.md
@@ -3,6 +3,36 @@
 This is a simple test script. It runs a number of commands in
 succession. This script also lists commands known not to work.
 
+## Basic Code block and results section
+
+Ensure things work with a bash code block in various formats.
+
+```bash
+# This is a code block, this comment will be ignored by SimDem
+echo "This command will be 'typed' and executed."
+```
+
+Code blocks can optionally be indented to make the markdown more 
+readable. For example:
+
+    ```
+    echo "Hello world indent"
+    ```
+
+Results:
+```expected_similarity=0.6
+Hello world indent
+```
+
+If a code block exists with a different language hint, it will not be
+execute, but instead will be output as formatted code, for example:
+
+```json
+{
+  Foo: "bar"
+}
+```
+
 # Setup
 
 Ensure the test environment is correctly setup.

--- a/demo_scripts/test/azureTests/README.md
+++ b/demo_scripts/test/azureTests/README.md
@@ -9,12 +9,13 @@ You need to use the environment variable $RESOURCE_GROUP_NAME for any resource g
 
 Create Azure resources
 
-```
+```bash
 echo $RESOURCE_GROUP_NAME
 ```
 
 Check resource group exists
-```
+
+```bash
 az group exists --name $RESOURCE_GROUP_NAME
 ```
 

--- a/demo_scripts/test/directory/README.md
+++ b/demo_scripts/test/directory/README.md
@@ -4,23 +4,23 @@ In this test ensures that the currrent working directory is set
 correctly when a test file is loaded as part of the test_plan.txt
 file, see [Issue #70](https://github.com/Azure/simdem/issues/70).
 
-Frst lets check the current working directory, this is useful for
+First lets check the current working directory, this is useful for
 debugging if the test fails.
 
-```
+```bash
 pwd
 ```
 
 Since we don't know exactly where this will be stored we need to check
 that we can open this file in the test.
 
-```
+```bash
 head -n 1 README.md
 ```
 
 Results: 
 
-``` Expected_Similarity=0.8
+```
 # Directory Check
 ```
 

--- a/demo_scripts/test/environment_test.md
+++ b/demo_scripts/test/environment_test.md
@@ -98,7 +98,7 @@ cat ../env.json
 Results:
 
 <!-- expected_similarity = 0.3 -->
-```json
+```expected_similarity = 0.3
 {
   "PARENT_TEST": "Hello from the parent"
 }
@@ -194,7 +194,7 @@ echo $CAPTURED_OUTPUT
 
 Results:
 
-```
+```expected_similarity = 0.2
 bar
 ```
 

--- a/demo_scripts/test/environment_test.md
+++ b/demo_scripts/test/environment_test.md
@@ -5,13 +5,13 @@ in which the command was given. Note that SimDem provides the
 environment variable `SIMDEM_EXEC_DIR` which provides access to this
 folder in SimDem scripts should it be necessary.
 
-```
+```bash
 cat $SIMDEM_EXEC_DIR/./env.json
 ```
 
 Results:
 
-```
+```json
 {
     "TEST": "Hello from the current working directory (where the simdem command was executed)"
 }
@@ -21,13 +21,13 @@ We should also be able to retrieve locallay defined environment
 variables from the directory in which the command was given:
 
 
-```
+```bash
 cat env.local.json
 ```
 
 Results:
 
-```
+```json
 {
     "TEST": "A local hello from the current working directory (where the simdem command was executed)"
 }
@@ -36,13 +36,13 @@ Results:
 There should also be environment variables in the the directory in
 which the current script resides.
 
-```
+```bash
 cat env.json
 ```
 
 Results:
 
-```
+```json
 {
     "TEST": "Hello from the test script",
     "DIR_IN_HOME": "~/should/be/expanded",
@@ -63,13 +63,13 @@ Results:
 Local variables can also be found in the the directory in which the
 current script resides.
 
-```
+```bash
 cat env.local.json
 ```
 
 Results:
 
-```
+```json
 {
     "TEST": "A local hello from the current working directory (where the simdem command was executed)"
 }
@@ -78,7 +78,7 @@ Results:
 For the `TEST` variable we should have the `env.local.json` value from
 the directory in which the application was executed.
 
-```
+```bash
 echo $TEST
 ```
 
@@ -91,13 +91,14 @@ A local hello from the current working directory (where the simdem command was e
 There should be variable definitions in the parent of the
 current script directory:
 
-```
+```bash
 cat ../env.json
 ```
 
 Results:
 
-```
+<!-- expected_similarity = 0.3 -->
+```json
 {
   "PARENT_TEST": "Hello from the parent"
 }
@@ -106,7 +107,7 @@ Results:
 Since the value of `PARENT_TEST` is only defined in this file we
 should have the value from there:
 
-```
+```bash
 echo $PARENT_TEST
 ```
 
@@ -127,7 +128,7 @@ you define it as an empty string in `env.json` if a value has been
 provided in `env.test.json`.
 
 
-```
+```bash
 echo $TEST_VALUE
 ```
 
@@ -144,7 +145,7 @@ commands will be replaced with an appropriate alternative,
 e.g. `curl`. Variables included in such commands will be expanded at
 execution time as expected.
 
-```
+```bash
 url=http://bing.com
 xdg-open $url
 ```
@@ -169,7 +170,7 @@ the SimDem environment. This includes setting to an empty string, this
 will prevent SimDem interactively requesting a value for the variable
 (or setting a dummt value in test mode).
 
-```
+```bash
 new_var=""
 echo $new_var
 ```
@@ -181,13 +182,13 @@ Results:
 
 # Capturing the output of commands
 
-```
+```bash
 CAPTURED_OUTPUT=$(echo foo | sed 's/foo/bar/')
 ```
 
 Captured value is:
 
-```
+```bash
 echo $CAPTURED_OUTPUT
 ```
 
@@ -201,6 +202,6 @@ bar
 
 '~' should be expanded to a home directory (no way to test this).
 
-```
+```bash
 echo $DIR_IN_HOME
 ```

--- a/demo_scripts/test/prerequisites/README.md
+++ b/demo_scripts/test/prerequisites/README.md
@@ -11,7 +11,7 @@ We should be able to run [nested prerequisites](./nested_prereq.md).
 
 # Create the test file
 
-```
+```bash
 touch $SIMDEM_TEMP_DIR/test/prereq_ran
 ```
 
@@ -21,7 +21,8 @@ If the `prereq_ran` file exists then we don't need to run this
 script. In our tests the setup phase removes this file so the
 validation test should always fail.
 
-```
+```bash
+echo temp is $SIMDEM_TEMP_DIR
 ls $SIMDEM_TEMP_DIR/test
 ```
 

--- a/demo_scripts/test/prerequisites/nested_prereq.md
+++ b/demo_scripts/test/prerequisites/nested_prereq.md
@@ -2,9 +2,9 @@
 
 This prerequisite is executed from the main prerequisite test file.
 
-# Create the test file
+# Create a test file
 
-```
+```bash
 touch $SIMDEM_TEMP_DIR/test/nested_prereq_ran
 ```
 
@@ -14,12 +14,12 @@ If the `prereq_ran` file exists then we don't need to run this
 script. In our tests the setup phase removes this file so the
 validation test should always fail.
 
-```
+```bash
 ls $SIMDEM_TEMP_DIR/test
 ```
 
 Results:
 
-```
+```expected_similarity=0.5
 nested_prereq_ran
 ```

--- a/demo_scripts/test/prerequisites/passing_prerequisite.md
+++ b/demo_scripts/test/prerequisites/passing_prerequisite.md
@@ -5,7 +5,7 @@ will always pass and thus the body of this script will never be
 executed. To ensure this is the case when we run tests we have placed
 a failing test in the body.
 
-```
+```bash
 echo "This test will always fail"
 ```
 
@@ -17,12 +17,14 @@ So we can ensure it never runs (the validation step will always pass)
 
 # Validation
 
-```
+This section is used to ensure that the commands in this document succeeded.
+
+```bash
 echo "This validation step is designed to always pass"
 ```
 
 Results:
 
-```
+```expected_similarity=0.5
 This validation step is designed to always pass
 ```


### PR DESCRIPTION
Add test case, documentation and fix for supporting language hints. This allows non-executable code blocks to be included in documentation. Fixes #116